### PR TITLE
fix: handle base href

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@okta/configuration-validation": "^1.0.0",
     "@okta/okta-auth-js": "^4.1.0",
     "tslib": "^1.9.0"
   },
@@ -122,7 +121,7 @@
     ],
     "globals": {
       "ts-jest": {
-        "tsConfig": "<rootDir>/test/spec/tsconfig.spec.json"
+        "tsconfig": "<rootDir>/test/spec/tsconfig.spec.json"
       }
     },
     "preset": "jest-preset-angular",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,9 +46,14 @@ export default {
             browser: true
         }),
         commonjs({
-            // namedExports: {
-            //     'node_modules/@okta/okta-auth-js/dist/okta-auth-js.umd.js': ['toRelativeUrl']
-            // }
+            namedExports: {
+                // TODO: why is this necessary?
+                'node_modules/@okta/okta-auth-js/dist/okta-auth-js.umd.js': [
+                  'toRelativeUrl',
+                  'isAbsoluteUrl',
+                  'toAbsoluteUrl'
+                ]
+            }
         }),
         sourcemaps()
     ],

--- a/src/okta/components/login-redirect.component.ts
+++ b/src/okta/components/login-redirect.component.ts
@@ -11,12 +11,17 @@
  */
 
 import { Component, OnInit } from '@angular/core';
+
 import { OktaAuthService } from '../services/okta.service';
 
 @Component({ template: `` })
 export class OktaLoginRedirectComponent implements OnInit {
   constructor(private okta: OktaAuthService) {}
   ngOnInit(): void {
+    const originalUri = this.okta.getOriginalUri();
+    if (!originalUri) {
+      this.okta.setOriginalUri('/');
+    }
     this.okta.signInWithRedirect();
   }
 }

--- a/src/okta/createService.ts
+++ b/src/okta/createService.ts
@@ -1,7 +1,8 @@
 import { Router } from '@angular/router';
+import { Location } from '@angular/common';
 import { OktaConfig } from './models/okta.config';
 import { OktaAuthService } from './services/okta.service';
 
-export function createOktaService(config: OktaConfig, router?: Router): OktaAuthService {
-  return new OktaAuthService(config, router);
+export function createOktaService(config: OktaConfig, location?: Location, router?: Router): OktaAuthService {
+  return new OktaAuthService(config, location, router);
 }

--- a/src/okta/okta.module.ts
+++ b/src/okta/okta.module.ts
@@ -12,6 +12,7 @@
 
 import { NgModule } from '@angular/core';
 import { Router } from '@angular/router';
+import { Location } from '@angular/common';
 import { OktaCallbackComponent } from './components/callback.component';
 import { OktaLoginRedirectComponent } from './components/login-redirect.component';
 import { OktaAuthService } from './services/okta.service';
@@ -35,6 +36,7 @@ import { createOktaService } from './createService';
       useFactory: createOktaService,
       deps: [
         OKTA_CONFIG,
+        Location, // optional
         Router // optional
       ]
     }

--- a/test/spec/service.test.ts
+++ b/test/spec/service.test.ts
@@ -39,20 +39,6 @@ describe("Angular service", () => {
       expect(createInstance()).toThrow();
     });
 
-    it("should throw if an issuer that does not contain https is provided", () => {
-      expect(createInstance({ issuer: "http://foo.com" })).toThrow();
-    });
-
-    it("should throw if an issuer matching {yourOktaDomain} is provided", () => {
-      expect(createInstance({ issuer: "https://{yourOktaDomain}" })).toThrow();
-    });
-
-    it("should throw if an issuer matching -admin.okta.com is provided", () => {
-      expect(
-        createInstance({ issuer: "https://foo-admin.okta.com" })
-      ).toThrow();
-    });
-
     it("should throw if an issuer matching -admin.oktapreview.com is provided", () => {
       expect(
         createInstance({ issuer: "https://foo-admin.oktapreview.com" })
@@ -62,29 +48,6 @@ describe("Angular service", () => {
     it("should throw if an issuer matching -admin.okta-emea.com is provided", () => {
       expect(
         createInstance({ issuer: "https://foo-admin.okta-emea.com" })
-      ).toThrow();
-    });
-
-    it("should throw if the client_id is not provided", () => {
-      expect(createInstance({ issuer: "https://foo" })).toThrow();
-    });
-
-    it("should throw if a client_id matching {clientId} is provided", () => {
-      expect(
-        createInstance({
-          clientId: "{clientId}",
-          issuer: "https://foo",
-        })
-      ).toThrow();
-    });
-
-    it("should throw if a redirectUri matching {redirectUri} is provided", () => {
-      expect(
-        createInstance({
-          clientId: "foo",
-          issuer: "https://foo",
-          redirectUri: "{redirectUri}",
-        })
       ).toThrow();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,15 +1421,7 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@okta/configuration-validation@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@okta/configuration-validation/-/configuration-validation-1.0.0.tgz#18d6220d139e7f5f3d203e11849e1ee61ca3cea1"
-  integrity sha512-CQaBdqP9fyYd2KwIgwwhWDivWx+Lwj7rtyXUbTlAHywKRwnEyNln7zUG6UaBBSRNK63I+W3A3GgPWO0gCpo1FA==
-  dependencies:
-    "@okta/okta-auth-js" "^4.0.0"
-    lodash "^4.17.15"
-
-"@okta/okta-auth-js@^4.0.0", "@okta/okta-auth-js@^4.1.0":
+"@okta/okta-auth-js@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.1.0.tgz#b1cb0ac5bb2918c703b461fb9a5c505f18d1db90"
   integrity sha512-ehPFay3+UirXL3F0NTE6yoqSo2idjJIL7ka/bJha129lHsi9fcXwvtwUz56hnn4qOlDQm8/qnHpF+/6HGoe3Eg==


### PR DESCRIPTION
- removes dependency on `configuration-validation` as it was causing warnings about commonjs modules
- better handling of `originalUri` and base href