### PR TITLE
Add Angular version in Okta UA. Add Angular to peer deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.2.0
+
+### Others
+
+- [#89](https://github.com/okta/okta-angular/pull/89) Updates okta-auth-js to 6.2.0 in test apps and SDK
+- [#91](https://github.com/okta/okta-angular/pull/91) Add Angular version in Okta UA. Add Angular to peerDependencies
+
 # 5.1.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "@okta/okta-auth-js": "^5.4.3 || ^6.0.0",
     "@angular/core": ">= 7.0.0",
     "@angular/router": ">= 7.0.0",
-    "@angular/common": ">= 7.0.0"
+    "@angular/common": ">= 7.0.0",
+    "rxjs": "^6.0.0 || ^7.0.0"
   },
   "jest": {
     "coverageDirectory": "<rootDir>/test-reports/coverage",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,10 @@
     "zone.js": "~0.8.26"
   },
   "peerDependencies": {
-    "@okta/okta-auth-js": "^5.4.3 || ^6.0.0"
+    "@okta/okta-auth-js": "^5.4.3 || ^6.0.0",
+    "@angular/core": ">= 7.0.0",
+    "@angular/router": ">= 7.0.0",
+    "@angular/common": ">= 7.0.0"
   },
   "jest": {
     "coverageDirectory": "<rootDir>/test-reports/coverage",

--- a/src/okta/okta.module.ts
+++ b/src/okta/okta.module.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { NgModule, Inject, Optional } from '@angular/core';
+import { NgModule, Inject, Optional, VERSION } from '@angular/core';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { OktaCallbackComponent } from './components/callback.component';
@@ -60,6 +60,7 @@ export class OktaAuthModule {
 
     // Add Okta UA
     oktaAuth._oktaUserAgent.addEnvironment(`${packageInfo.name}/${packageInfo.version}`);
+    oktaAuth._oktaUserAgent.addEnvironment(`Angular/${VERSION.full}`);
 
     // Provide a default implementation of `restoreOriginalUri`
     if (!oktaAuth.options.restoreOriginalUri && router && location) {


### PR DESCRIPTION
- Add Angular version in `X-Okta-User-Agent-Extended`
- Add Angular (>= 7) to peer dependencies

Internal ref: [OKTA-469350](https://oktainc.atlassian.net/browse/OKTA-469350)