### PR TITLE
Fix: handle routes without path segments

### DIFF
--- a/src/okta/okta.guard.ts
+++ b/src/okta/okta.guard.ts
@@ -17,7 +17,7 @@ import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
   Router,
-  NavigationStart, 
+  NavigationStart,
   Event,
   CanLoad,
   Route,
@@ -36,10 +36,10 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
 
 
   constructor(
-    @Inject(OKTA_CONFIG) private config: OktaConfig, 
-    @Inject(OKTA_AUTH) private oktaAuth: OktaAuth, 
+    @Inject(OKTA_CONFIG) private config: OktaConfig,
+    @Inject(OKTA_AUTH) private oktaAuth: OktaAuth,
     private injector: Injector
-  ) { 
+  ) {
     this.onAuthRequired = this.config.onAuthRequired;
 
     // Unsubscribe updateAuthStateListener when route change
@@ -59,7 +59,7 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
       return true;
     }
 
-    const originalUri = segments[0].path;
+    const originalUri = segments.length > 0 ? segments[0].path : '';
     await this.handleLogin(originalUri);
 
     return false;

--- a/test/spec/guard.test.ts
+++ b/test/spec/guard.test.ts
@@ -7,13 +7,13 @@ import {
   OKTA_CONFIG,
 } from '../../src/okta-angular';
 import { AuthRequiredFunction } from '../../src/okta/models/okta.config';
-import { 
-  ActivatedRouteSnapshot, 
-  RouterStateSnapshot, 
-  Router, 
-  RouterState, 
-  Route, 
-  UrlSegment 
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  Router,
+  RouterState,
+  Route,
+  UrlSegment
 } from '@angular/router';
 import { Injector } from '@angular/core';
 import { OktaAuth } from '@okta/okta-auth-js';
@@ -100,6 +100,11 @@ describe('Angular auth guard', () => {
         segments[0].path = `${baseUrl}${query}${hash}`;
         await guard.canLoad(route, segments);
         expect(oktaAuth.setOriginalUri).toHaveBeenCalledWith('http://fake.url/path?query=foo&bar=baz#hash=foo');
+      });
+
+      it('calls "setOriginalUri" without route segments', async () => {
+        await guard.canLoad(route, []);
+        expect(oktaAuth.setOriginalUri).toHaveBeenCalledWith('');
       });
 
       it('onAuthRequired can be set on route', async () => {


### PR DESCRIPTION
Protect lazy loaded routes without path segments with canLoad-Guard.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-angular/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you want to protect a route without any path segments with a canLoad-Guard, an exception is thrown.
```typescript
const routes = [{
 path: '',
 canLoad: [ OktaAuthGuard ],
 ...
}]
```

Issue Number: N/A


## What is the new behavior?
Routes without path segments can be protected with a canLoad-Guard.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

