### PR TITLE
Use siw-platform-scripts instead of artifactory url 

### DIFF
--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -2,6 +2,11 @@
 
 source ${OKTA_HOME}/${REPO}/scripts/setup-e2e.sh
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping e2e tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 setup_service java 1.8.222
 setup_service google-chrome-stable 106.0.5249.61-1
 
@@ -10,10 +15,9 @@ export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
 export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
-export WEB_CLIENT_ID=0oapmx9r5dK1dDAd54x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/client_secret CLIENT_SECRET
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -13,11 +13,11 @@ setup_service google-chrome-stable 106.0.5249.61-1
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
-export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
-export USERNAME=mary@acme.com
-get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
-export ORG_OIE_ENABLED=true
+export ISSUER=https://samples-javascript.okta.com/oauth2/default
+export SPA_CLIENT_ID=0oapmwm72082GXal14x6
+export USERNAME=george@acme.com
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -13,11 +13,11 @@ setup_service google-chrome-stable 106.0.5249.61-1
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://samples-javascript.okta.com/oauth2/default
-export SPA_CLIENT_ID=0oapmwm72082GXal14x6
-export USERNAME=george@acme.com
-get_vault_secret_key devex/samples-javascript password PASSWORD
-export ORG_OIE_ENABLED=
+export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
+export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
+export USERNAME=mary@acme.com
+get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
+export ORG_OIE_ENABLED=true
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,11 +8,11 @@ setup_service google-chrome-stable 106.0.5249.61-1
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://samples-javascript.okta.com/oauth2/default
-export SPA_CLIENT_ID=0oapmwm72082GXal14x6
-export USERNAME=george@acme.com
-get_vault_secret_key devex/samples-javascript password PASSWORD
-export ORG_OIE_ENABLED=
+export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
+export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
+export USERNAME=mary@acme.com
+get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
+export ORG_OIE_ENABLED=true
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -10,10 +10,9 @@ export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
 export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
-export WEB_CLIENT_ID=0oapmx9r5dK1dDAd54x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/client_secret CLIENT_SECRET
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,11 +8,11 @@ setup_service google-chrome-stable 106.0.5249.61-1
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
-export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
-export USERNAME=mary@acme.com
-get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
-export ORG_OIE_ENABLED=true
+export ISSUER=https://samples-javascript.okta.com/oauth2/default
+export SPA_CLIENT_ID=0oapmwm72082GXal14x6
+export USERNAME=george@acme.com
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/scripts/selenium-test.sh
+++ b/scripts/selenium-test.sh
@@ -19,7 +19,7 @@ unzip chromedriver_linux64.zip
 mv chromedriver /usr/bin/chromedriver
 chown root:root /usr/bin/chromedriver
 chmod +x /usr/bin/chromedriver
-get_secret prod/okta-sdk-vars/password SIW_TEST_USER_PASSWORD
+get_vault_secret_key devex/samples-javascript password SIW_TEST_USER_PASSWORD
 export SIW_TEST_USER_EMAIL=george@acme.com
 if ! node /root/okta/okta-angular/test/selenium-test/selenium/okta-angular-widget-test.ts; then
   echo "Test failed! Exiting..."

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -32,16 +32,16 @@ install_auth_js () {
   fi
 }
 
+# Install required node version
+export NVM_DIR="/root/.nvm"
+setup_service node v16.13.2
+
 # Install yarn
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 # Add yarn to the $PATH so npm cli commands do not fail
 export PATH="${PATH}:$(yarn global bin)"
-
-# Install required node version
-export NVM_DIR="/root/.nvm"
-setup_service node v16.13.2
 
 yarn global add yalc
 

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -7,7 +7,7 @@ source $DIR/utils/siw-platform-scripts.sh
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION="7.4.0-g64ea6df"
+export AUTHJS_VERSION=""
 
 # Install a specific version of auth-js, used by downstream artifact builds
 install_auth_js () {

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -1,28 +1,29 @@
 #!/bin/bash -xe
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
+source $DIR/utils/siw-platform-scripts.sh
+
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION=""
+export AUTHJS_VERSION="7.4.0-g64ea6df"
 
 # Install a specific version of auth-js, used by downstream artifact builds
 install_auth_js () {
   if [ ! -z "$AUTHJS_VERSION" ]; then
-    echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
-    npm config set strict-ssl false
-
-    AUTHJS_URI=https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz
-    if ! yarn add -DW --ignore-scripts ${AUTHJS_URI}; then
-      echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
-      exit ${FAILED_SETUP}
-    fi
-
-    npm config set strict-ssl true
-    echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
+    echo "Installing AUTHJS_VERSION for $1: ${AUTHJS_VERSION}"
+    install_siw_platform_scripts
+    install_artifact @okta/okta-auth-js "${AUTHJS_VERSION}"
+    echo "AUTHJS_VERSION installed for $1: ${AUTHJS_VERSION}"
 
     # verify single version of auth-js is installed
     # NOTE: okta-signin-widget will install it's own version of auth-js, filtered out
-    AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
+    exclude=""
+    if [ "$1" == "root" ]; then
+      exclude="-not -path */test/apps/angular-*/*"
+    fi
+    AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" ${exclude} | wc -l)
     if [ $AUTHJS_INSTALLS -gt 1 ]; then
       echo "ADDITIONAL AUTH JS INSTALL DETECTED"
       yarn why @okta/okta-auth-js
@@ -46,32 +47,17 @@ yarn global add yalc
 
 cd ${OKTA_HOME}/${REPO}
 
-# undo permissions change on scripts/publish.sh
-git checkout -- scripts
+if [ -n "${TEST_SUITE_ID}" ]; then
+  # undo permissions change on scripts/publish.sh
+  git checkout -- scripts
 
-# ensure we're in a branch on the correct sha
-git checkout $BRANCH
-git reset --hard $SHA
+  # ensure we're in a branch on the correct sha
+  git checkout $BRANCH
+  git reset --hard $SHA
 
-git config --global user.email "oktauploader@okta.com"
-git config --global user.name "oktauploader-okta"
-
-#!/bin/bash
-YARN_REGISTRY=https://registry.yarnpkg.com
-OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
-
-# Yarn does not utilize the npmrc/yarnrc registry configuration
-# if a lockfile is present. This results in `yarn install` problems
-# for private registries. Until yarn@2.0.0 is released, this is our current
-# workaround.
-#
-# Related issues:
-#  - https://github.com/yarnpkg/yarn/issues/5892
-#  - https://github.com/yarnpkg/yarn/issues/3330
-
-# Replace yarn registry with Okta's
-echo "Replacing $YARN_REGISTRY with $OKTA_REGISTRY within yarn.lock files..."
-find . -type d -name node_modules -prune -o -name 'yarn.lock' -print -exec sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#" {} +
+  git config --global user.email "oktauploader@okta.com"
+  git config --global user.name "oktauploader-okta"
+fi
 
 # Install dependencies but do not build
 if ! yarn install --frozen-lockfile --ignore-scripts; then
@@ -80,7 +66,7 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
 fi
 
 # Install a specific version of auth-js
-install_auth_js
+install_auth_js "root"
 
 # Build
 if ! yarn build; then
@@ -95,10 +81,6 @@ for app in test/apps/angular-*
 do
   pushd $app
     yarn install
-    install_auth_js
+    install_auth_js $app
   popd
 done
-
-# Revert the original change(s)
-echo "Replacing $OKTA_REGISTRY with $YARN_REGISTRY within yarn.lock files..."
-find . -type d -name node_modules -prune -o -name 'yarn.lock' -print -exec sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" {} +

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -47,6 +47,7 @@ yarn global add yalc
 
 cd ${OKTA_HOME}/${REPO}
 
+# if running on bacon
 if [ -n "${TEST_SUITE_ID}" ]; then
   # undo permissions change on scripts/publish.sh
   git checkout -- scripts

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,6 +41,7 @@ export PATH="${PATH}:$(yarn global bin)"
 
 cd ${OKTA_HOME}/${REPO}
 
+# if running on bacon
 if [ -n "${TEST_SUITE_ID}" ]; then
   # undo permissions change on scripts/publish.sh
   git checkout -- scripts

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@ source $DIR/utils/siw-platform-scripts.sh
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION="7.4.0-g64ea6df"
+export AUTHJS_VERSION=""
 
 # Install a specific version of auth-js, used by downstream artifact builds
 install_auth_js () {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,16 +28,16 @@ install_auth_js () {
   fi
 }
 
+# Install required node version
+export NVM_DIR="/root/.nvm"
+setup_service node v16.13.2
+
 # Install yarn
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 # Add yarn to the $PATH so npm cli commands do not fail
 export PATH="${PATH}:$(yarn global bin)"
-
-# Install required node version
-export NVM_DIR="/root/.nvm"
-setup_service node v16.13.2
 
 cd ${OKTA_HOME}/${REPO}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,28 +1,25 @@
 #!/bin/bash -xe
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
+source $DIR/utils/siw-platform-scripts.sh
+
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION=""
+export AUTHJS_VERSION="7.4.0-g64ea6df"
 
 # Install a specific version of auth-js, used by downstream artifact builds
 install_auth_js () {
   if [ ! -z "$AUTHJS_VERSION" ]; then
     echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
-    npm config set strict-ssl false
-
-    AUTHJS_URI=https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz
-    if ! yarn add -DW --ignore-scripts ${AUTHJS_URI}; then
-      echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
-      exit ${FAILED_SETUP}
-    fi
-
-    npm config set strict-ssl true
+    install_siw_platform_scripts
+    install_artifact @okta/okta-auth-js "${AUTHJS_VERSION}"
     echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
 
     # verify single version of auth-js is installed
     # NOTE: okta-signin-widget will install it's own version of auth-js, filtered out
-    AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
+    AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" -not -path "*/test/apps/angular-*/*"  | wc -l)
     if [ $AUTHJS_INSTALLS -gt 1 ]; then
       echo "ADDITIONAL AUTH JS INSTALL DETECTED"
       yarn why @okta/okta-auth-js
@@ -44,42 +41,23 @@ setup_service node v16.13.2
 
 cd ${OKTA_HOME}/${REPO}
 
-# undo permissions change on scripts/publish.sh
-git checkout -- scripts
+if [ -n "${TEST_SUITE_ID}" ]; then
+  # undo permissions change on scripts/publish.sh
+  git checkout -- scripts
 
-# ensure we're in a branch on the correct sha
-git checkout $BRANCH
-git reset --hard $SHA
+  # ensure we're in a branch on the correct sha
+  git checkout $BRANCH
+  git reset --hard $SHA
 
-git config --global user.email "oktauploader@okta.com"
-git config --global user.name "oktauploader-okta"
-
-#!/bin/bash
-YARN_REGISTRY=https://registry.yarnpkg.com
-OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
-
-# Yarn does not utilize the npmrc/yarnrc registry configuration
-# if a lockfile is present. This results in `yarn install` problems
-# for private registries. Until yarn@2.0.0 is released, this is our current
-# workaround.
-#
-# Related issues:
-#  - https://github.com/yarnpkg/yarn/issues/5892
-#  - https://github.com/yarnpkg/yarn/issues/3330
-
-# Replace yarn registry with Okta's
-echo "Replacing $YARN_REGISTRY with $OKTA_REGISTRY within yarn.lock files..."
-sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#" yarn.lock
+  git config --global user.email "oktauploader@okta.com"
+  git config --global user.name "oktauploader-okta"
+fi
 
 # Install dependencies but do not build
 if ! yarn install --frozen-lockfile --ignore-scripts; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
-
-# Revert the original change(s)
-echo "Replacing $OKTA_REGISTRY with $YARN_REGISTRY within yarn.lock files..."
-sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock
 
 # Install a specific version of auth-jss
 install_auth_js

--- a/scripts/unit-v6.sh
+++ b/scripts/unit-v6.sh
@@ -2,6 +2,11 @@
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping e2e tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/unit"
 

--- a/scripts/unit-v6.sh
+++ b/scripts/unit-v6.sh
@@ -3,7 +3,7 @@
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 if [ ! -z "$AUTHJS_VERSION" ]; then
-  echo "Skipping e2e tests against auth-js v6.x"
+  echo "Skipping unit tests against auth-js v6.x"
   exit ${SUCCESS}
 fi
 

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# if not running on bacon
+if [ -z "${TEST_SUITE_ID}" ]; then
+  export OKTA_HOME=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd)
+  export REPO="."
+  export TEST_SUITE_TYPE_FILE=/dev/null
+  export TEST_RESULT_FILE_DIR_FILE=/dev/null
+
+  ### (known) Bacon exit codes
+  # success
+  export SUCCESS=0
+  export PUBLISH_TYPE_AND_RESULT_DIR=0
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_SUCCEED_IF_NO_RESULTS=0
+  # failure
+  export FAILURE=1
+  export FAILED_SETUP=1
+  export TEST_FAILURE=1
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL=1
+  export PUBLISH_ARTIFACTORY_FAILURE=1
+
+  # bacon commands
+  setup_service () {
+    echo 'noop'
+  }
+
+  get_secret () {
+    # ensures the env var is set
+    if [ -z "$(echo "$3")" ]; then
+      echo "$3 is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  set -x  # when running locally, might as well see all the commands being ran
+fi

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -25,11 +25,7 @@ if [ -z "${TEST_SUITE_ID}" ]; then
   }
 
   get_secret () {
-    # ensures the env var is set
-    if [ -z "$(echo "$3")" ]; then
-      echo "$3 is not defined. Exiting..."
-      exit 1
-    fi
+    echo 'noop'
   }
 
   set -x  # when running locally, might as well see all the commands being ran

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -25,7 +25,21 @@ if [ -z "${TEST_SUITE_ID}" ]; then
   }
 
   get_secret () {
-    echo 'noop'
+    # ensures the env var is set
+    key="$2"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  get_vault_secret_key () {
+    # ensures the env var is set
+    key="$3"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
   }
 
   set -x  # when running locally, might as well see all the commands being ran

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# if running on bacon
+if [ -n "${TEST_SUITE_ID}" ]; then
+  export SIW_PLATFORM_ENV="bacon"
+else
+  export SIW_PLATFORM_ENV="local"
+fi
+
+orig_ssl=$(yarn config get strict-ssl)
+orig_registry=$(yarn config get @okta:registry)
+REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
+
+update_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    yarn config set @okta:registry ${REGISTRY}
+    yarn config set strict-ssl false
+    trap restore_yarn_config EXIT
+  fi
+}
+
+restore_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    if [ "$orig_registry" == "undefined" ] ; then
+      yarn config delete @okta:registry
+    else
+      yarn config set @okta:registry $orig_registry
+    fi
+    yarn config set strict-ssl $orig_ssl
+  fi
+}
+
+install_siw_platform_scripts () {
+  update_yarn_config
+  if ! yarn global add @okta/siw-platform-scripts ; then
+    echo "siw-platform-scripts could not be installed"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}
+
+install_artifact () {
+  # $1 = package name
+  # $2 = version
+  update_yarn_config
+  if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
+    echo "$1 could not be installed via siw-platform: $1"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -44,7 +44,7 @@ install_artifact () {
   # $2 = version
   update_yarn_config
   if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
-    echo "$1 could not be installed via siw-platform: $1"
+    echo "$1 $2 could not be installed via siw-platform"
     exit ${FAILED_SETUP}
   fi
   restore_yarn_config

--- a/test/e2e/pageobjects/okta-signin-oie.page.js
+++ b/test/e2e/pageobjects/okta-signin-oie.page.js
@@ -1,0 +1,18 @@
+class OktaSignInPage {
+    get username () { return $('[name="identifier"]'); }
+    get password () { return $('[name="credentials.passcode"]'); }
+    get submit () { return $('[data-type="save"]'); }
+  
+    async waitForLoad() {
+      return browser.waitUntil(async () => this.submit.then(el => el.isDisplayed()), 5000, 'wait for signin btn');
+    }
+  
+    async signIn({ username, password }) {
+      await this.username.setValue(username);
+      await this.password.setValue(password);
+      await this.submit.click();
+    }
+  }
+  
+  export default new OktaSignInPage();
+  

--- a/test/e2e/specs/app.e2e.js
+++ b/test/e2e/specs/app.e2e.js
@@ -11,13 +11,19 @@
  */
 
 import AppPage from '../pageobjects/app.page';
-import OktaSignInPage from '../pageobjects/okta-signin.page';
+import OktaSignInPageV1 from '../pageobjects/okta-signin.page';
+import OktaSignInPageOIE from '../pageobjects/okta-signin-oie.page';
 import ProtectedPage from '../pageobjects/protected.page';
 import LazyPage from '../pageobjects/lazy.page';
 import SessionTokenSignInPage from '../pageobjects/sessiontoken-signin.page';
 import PublicPage from '../pageobjects/public.page';
 import HasGroupPage from '../pageobjects/has-group.page';
 import { waitForLoad } from '../util/waitUtil';
+
+let OktaSignInPage = OktaSignInPageV1;
+if (process.env.ORG_OIE_ENABLED) {
+  OktaSignInPage = OktaSignInPageOIE;
+}
 
 describe('Angular + Okta App', () => {
   


### PR DESCRIPTION
- Use `siw-platform-scripts` to install auth-js instead of internal artifactory url
- Added support of [local running](https://github.com/okta/okta-angular/pull/128/files#diff-2e35321119f1354c7c96c55fe060acb9a16f68c56114f9a0e0d6560b193cb986) e2e and setup scripts
- Added support of [OIE org for e2e tests](https://github.com/okta/okta-angular/pull/128/files#diff-e5578d910e6292d7f5129f6fab014c586e170b3ef7ff0e5e4c8bd285bae0b466)
- Cleaned up e2e script: Removed unused env vars for e2e script: [WEB_CLIENT_ID](https://github.com/okta/okta-angular/pull/128/files#diff-c4c4d7d957024f9161f5951e3a31fc43ca058c5751bca6dad26cbe1fdc1d395fL13), CLIENT_SECRET.  Removed obsolete [registry workaround for yarn](https://github.com/okta/okta-angular/pull/128/files#diff-fbe4608d19692209377719610da990a0c5bfea326b75144a744df7c4a54f76beL63-L74).

Internal ref: [OKTA-607422](https://oktainc.atlassian.net/browse/OKTA-607422)