### PR TITLE
Support Step-up authentication in OktaAuthGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.3.0
+
+### Features
+
+- [#132](https://github.com/okta/okta-angular/pull/132) Supports Step-up authentication in `OktaAuthGuard` by specifying `okta.acrValues` in route data
+
 # 6.2.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const appRoutes: Routes = [
 ]
 ```
 
-To protect a route with [the assurance level](https://developer.okta.com/docs/guides/step-up-authentication/main/), add []`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) to route data:
+To protect a route with [the assurance level](https://developer.okta.com/docs/guides/step-up-authentication/main/), add [`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) to route data:
 
 ```typescript
 // myApp.module.ts

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ export class MyAppModule { }
 An Angular InjectionToken used to configure the OktaAuthModule. This value must be provided by your own application.
 
 - `oktaAuth` *(required)*: - [OktaAuth][@okta/okta-auth-js] instance. The instance that can be shared cross different components of the application. One popular use case is to share one single instance cross the application and [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget).
-- `onAuthRequired` *(optional)*: - callback function. Triggered when a route protected by `OktaAuthGuard` is accessed without authentication or without needed level of end-user assurance (if `acrValues` is provided in route data). Use this to present a [custom login page](#using-a-custom-login-page). If no `onAuthRequired` callback is defined, `okta-angular` will redirect directly to Okta for authentication.
+- `onAuthRequired` *(optional)*: - callback function. Triggered when a route protected by `OktaAuthGuard` is accessed without authentication or without needed level of end-user assurance (if `okta.acrValues` is provided in route data). Use this to present a [custom login page](#using-a-custom-login-page). If no `onAuthRequired` callback is defined, `okta-angular` will redirect directly to Okta for authentication.
 - `onAuthResume` *(optional)*: - callback function. Only relevant if using a [custom login page](#using-a-custom-login-page). Called when the [authentication flow should be resumed by the application](#resuming-the-authentication-flow), typically as a result of redirect callback from an [external identity provider][]. If not defined, `onAuthRequired` will be called.
 
 ### `OKTA_AUTH`
@@ -232,7 +232,7 @@ export class MyProtectedComponent implements OnInit {
 The top-level Angular module which provides these components and services:
 
 - [`OktaAuth`][@okta/okta-auth-js] - The passed in [`OktaAuth`][@okta/okta-auth-js] instance with default behavior setup.
-- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard implementing [CanActivate](https://angular.io/api/router/CanActivate) and [CanActivateChild](https://angular.io/api/router/CanActivateChild) to grant access to a page (and/or its children) only after successful authentication (and only with needed level of end-user assurance if `acrValues` is provided in route data).
+- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard implementing [CanActivate](https://angular.io/api/router/CanActivate) and [CanActivateChild](https://angular.io/api/router/CanActivateChild) to grant access to a page (and/or its children) only after successful authentication (and only with needed level of end-user assurance if `okta.acrValues` is provided in route data).
 - [`OktaCallbackComponent`](#oktacallbackcomponent) - Handles the implicit flow callback by parsing tokens from the URL and storing them automatically.
 - [`OktaAuthStateService`](#oktaauthstateservice) - A data service exposing observable [authState$][AuthState].
 
@@ -240,7 +240,7 @@ The top-level Angular module which provides these components and services:
 
 Routes are protected by the `OktaAuthGuard`, which verifies there is a valid `accessToken` stored.  
 
-To verify the level of end-user assurance (see [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/)), add `acrValues` to route data. Then `OktaAuthGuard` will also verify `acr` claim of `accessToken` to match provided `acrValues`. See [list of supported ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values). Minimum supported version of `@okta/okta-auth-js` for this feature is `7.1.0`.  
+To verify the level of end-user assurance (see [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/)), add `acrValues` to route data in `okta` namespace. Then `OktaAuthGuard` will also verify `acr` claim of `accessToken` to match provided `okta.acrValues`. See [list of supported ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values). Minimum supported version of `@okta/okta-auth-js` for this feature is `7.1.0`.  
 
 To ensure the user has been authenticated before accessing your route, add the `canActivate` guard to one of your routes:
 
@@ -266,7 +266,7 @@ const appRoutes: Routes = [
 ]
 ```
 
-To protect a route with [the assurance level](https://developer.okta.com/docs/guides/step-up-authentication/main/), add [`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) to route data:
+To protect a route with [the assurance level](https://developer.okta.com/docs/guides/step-up-authentication/main/), add [`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) to route data in `okta` namespace:
 
 ```typescript
 // myApp.module.ts
@@ -279,8 +279,10 @@ const appRoutes: Routes = [
     component: MyProtectedComponent,
     canActivate: [ OktaAuthGuard ],
     data: {
-      // requires any 2 factors before accessing the route
-      acrValues: 'urn:okta:loa:2fa:any'
+      okta: {
+        // requires any 2 factors before accessing the route
+        acrValues: 'urn:okta:loa:2fa:any'
+      }
     },
   },
   ...

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This library currently supports:
 - [OAuth 2.0 Implicit Flow](https://tools.ietf.org/html/rfc6749#section-1.3.2)
 - [OAuth 2.0 Authorization Code Flow](https://tools.ietf.org/html/rfc6749#section-1.3.1) with [Proof Key for Code Exchange (PKCE)](https://tools.ietf.org/html/rfc7636)
 
-> This library has been tested for compatibility with the following Angular versions: 7, 8, 9, 10, 11, 12, 13, 14, 15
+> This library has been tested for compatibility with the following Angular versions: 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 > :warning: `okta-angular` 6.0+ supports Angular 12+. For Angular 7 to 11 please use `okta-angular` 5.x
 > :warning: Angular versions older than 7 may not be fully compatible with all dependencies of this library, due to an older Typescript version which does not contain a definition for the `unknown` type. You may be able to workaround this issue by setting `skipLibChecks: true` in your `tsconfig.json` file.
 
@@ -198,7 +198,7 @@ export class MyAppModule { }
 An Angular InjectionToken used to configure the OktaAuthModule. This value must be provided by your own application.
 
 - `oktaAuth` *(required)*: - [OktaAuth][@okta/okta-auth-js] instance. The instance that can be shared cross different components of the application. One popular use case is to share one single instance cross the application and [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget).
-- `onAuthRequired` *(optional)*: - callback function. Triggered when a route protected by `OktaAuthGuard` is accessed without authentication. Use this to present a [custom login page](#using-a-custom-login-page). If no `onAuthRequired` callback is defined, `okta-angular` will redirect directly to Okta for authentication.
+- `onAuthRequired` *(optional)*: - callback function. Triggered when a route protected by `OktaAuthGuard` is accessed without authentication or without needed level of end-user assurance (if `acrValues` is provided in route data). Use this to present a [custom login page](#using-a-custom-login-page). If no `onAuthRequired` callback is defined, `okta-angular` will redirect directly to Okta for authentication.
 - `onAuthResume` *(optional)*: - callback function. Only relevant if using a [custom login page](#using-a-custom-login-page). Called when the [authentication flow should be resumed by the application](#resuming-the-authentication-flow), typically as a result of redirect callback from an [external identity provider][]. If not defined, `onAuthRequired` will be called.
 
 ### `OKTA_AUTH`
@@ -232,13 +232,17 @@ export class MyProtectedComponent implements OnInit {
 The top-level Angular module which provides these components and services:
 
 - [`OktaAuth`][@okta/okta-auth-js] - The passed in [`OktaAuth`][@okta/okta-auth-js] instance with default behavior setup.
-- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard implementing [CanActivate](https://angular.io/api/router/CanActivate) and [CanActivateChild](https://angular.io/api/router/CanActivateChild) to grant access to a page (and/or its children) only after successful authentication.
+- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard implementing [CanActivate](https://angular.io/api/router/CanActivate) and [CanActivateChild](https://angular.io/api/router/CanActivateChild) to grant access to a page (and/or its children) only after successful authentication (and only with needed level of end-user assurance if `acrValues` is provided in route data).
 - [`OktaCallbackComponent`](#oktacallbackcomponent) - Handles the implicit flow callback by parsing tokens from the URL and storing them automatically.
 - [`OktaAuthStateService`](#oktaauthstateservice) - A data service exposing observable [authState$][AuthState].
 
 ### `OktaAuthGuard`
 
-Routes are protected by the `OktaAuthGuard`, which verifies there is a valid `accessToken` stored. To ensure the user has been authenticated before accessing your route, add the `canActivate` guard to one of your routes:
+Routes are protected by the `OktaAuthGuard`, which verifies there is a valid `accessToken` stored.  
+
+To verify the level of end-user assurance (see [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/)), add `acrValues` to route data. Then `OktaAuthGuard` will also verify `acr` claim of `accessToken` to match provided `acrValues`. See [list of supported ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values).  
+
+To ensure the user has been authenticated before accessing your route, add the `canActivate` guard to one of your routes:
 
 ```typescript
 // myApp.module.ts
@@ -257,6 +261,27 @@ const appRoutes: Routes = [
       // children of a protected route are also protected
       path: 'also-protected'
     }]
+  },
+  ...
+]
+```
+
+To protect a route with [the assurance level](https://developer.okta.com/docs/guides/step-up-authentication/main/), add []`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) to route data:
+
+```typescript
+// myApp.module.ts
+
+import { OktaAuthGuard } from '@okta/okta-angular';
+
+const appRoutes: Routes = [
+  {
+    path: 'protected',
+    component: MyProtectedComponent,
+    canActivate: [ OktaAuthGuard ],
+    data: {
+      // requires any 2 factors before accessing the route
+      acrValues: 'urn:okta:loa:2fa:any'
+    },
   },
   ...
 ]
@@ -408,7 +433,9 @@ To implement a custom login page, set an `onAuthRequired` callback on the `OktaC
 ```typescript
 // myApp.module.ts
 
-function onAuthRequired(oktaAuth, injector) {
+function onAuthRequired(oktaAuth, injector, options) {
+  // `options` object can contain `acrValues` if it was provided in route data
+
   // Use injector to access any service available within your application
   const router = injector.get(Router);
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The top-level Angular module which provides these components and services:
 
 Routes are protected by the `OktaAuthGuard`, which verifies there is a valid `accessToken` stored.  
 
-To verify the level of end-user assurance (see [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/)), add `acrValues` to route data. Then `OktaAuthGuard` will also verify `acr` claim of `accessToken` to match provided `acrValues`. See [list of supported ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values).  
+To verify the level of end-user assurance (see [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/)), add `acrValues` to route data. Then `OktaAuthGuard` will also verify `acr` claim of `accessToken` to match provided `acrValues`. See [list of supported ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values). Minimum supported version of `@okta/okta-auth-js` for this feature is `7.1.0`.  
 
 To ensure the user has been authenticated before accessing your route, add the `canActivate` guard to one of your routes:
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-angular",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Angular support for Okta",
   "repository": "https://github.com/okta/okta-angular",
   "homepage": "https://github.com/okta/okta-angular",

--- a/lib/src/okta/models/okta.config.ts
+++ b/lib/src/okta/models/okta.config.ts
@@ -11,9 +11,9 @@
  */
 
 import { InjectionToken, Injector } from '@angular/core';
-import { OktaAuth } from '@okta/okta-auth-js';
+import { OktaAuth, TokenParams } from '@okta/okta-auth-js';
 
-export type AuthRequiredFunction = (oktaAuth: OktaAuth, injector: Injector) => void;
+export type AuthRequiredFunction = (oktaAuth: OktaAuth, injector: Injector, options?: TokenParams) => void;
 
 export interface TestingObject {
   disableHttpsCheck: boolean;

--- a/lib/src/okta/okta.guard.ts
+++ b/lib/src/okta/okta.guard.ts
@@ -105,11 +105,11 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
   private async isAuthenticated(routeData?: Data, authState?: AuthState | null) {
     const isAuthenticated = authState ? authState?.isAuthenticated : await this.oktaAuth.isAuthenticated();
     let res = isAuthenticated;
-    if (routeData?.acrValues) {
+    if (routeData?.okta?.acrValues) {
       if (!authState) {
         authState = this.oktaAuth.authStateManager.getAuthState();
       }
-      res = authState?.accessToken?.claims.acr === routeData?.acrValues;
+      res = authState?.accessToken?.claims.acr === routeData?.okta?.acrValues;
     }
     return res;
   }
@@ -121,10 +121,10 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
     }
 
     const options: TokenParams = {};
-    if (routeData?.acrValues) {
+    if (routeData?.okta?.acrValues) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore Supports auth-js >= 7.1.0
-      options.acrValues = routeData.acrValues;
+      options.acrValues = routeData.okta.acrValues;
     }
 
     if (this.onAuthRequired) {

--- a/lib/src/okta/okta.guard.ts
+++ b/lib/src/okta/okta.guard.ts
@@ -35,7 +35,6 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
   private routeData: Data;
   private onAuthRequired?: AuthRequiredFunction;
 
-
   constructor(
     @Inject(OKTA_AUTH) private oktaAuth: OktaAuth, 
     private injector: Injector,

--- a/lib/src/okta/okta.guard.ts
+++ b/lib/src/okta/okta.guard.ts
@@ -129,6 +129,8 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
 
     const options: TokenParams = {};
     if (routeData?.acrValues) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore Supports auth-js >= 7.1.0
       options.acrValues = routeData.acrValues;
     }
 

--- a/lib/src/okta/okta.guard.ts
+++ b/lib/src/okta/okta.guard.ts
@@ -25,11 +25,9 @@ import {
 } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
-import { OktaAuth, AuthState, TokenParams, AuthSdkError } from '@okta/okta-auth-js';
+import { OktaAuth, AuthState, TokenParams } from '@okta/okta-auth-js';
 import { OktaAuthConfigService } from './services/auth-config.serice';
 import { AuthRequiredFunction, OKTA_AUTH } from './models/okta.config';
-import { compare } from 'compare-versions';
-import packageInfo from './packageInfo';
 
 @Injectable()
 export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
@@ -109,10 +107,6 @@ export class OktaAuthGuard implements CanActivate, CanActivateChild, CanLoad {
     const isAuthenticated = authState ? authState?.isAuthenticated : await this.oktaAuth.isAuthenticated();
     let res = isAuthenticated;
     if (routeData?.acrValues) {
-      const isSupported = this.oktaAuth._oktaUserAgent && compare(this.oktaAuth._oktaUserAgent.getVersion(), packageInfo.authJSMinSupportedVersionForAcr, '>=');
-      if (!isSupported) {
-        throw new AuthSdkError(`Passed in oktaAuth does not support ACR values, minimum supported okta-auth-js version is ${packageInfo.authJSMinSupportedVersionForAcr}.`);
-      }
       if (!authState) {
         authState = this.oktaAuth.authStateManager.getAuthState();
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@angular/router": "~12.2.0",
     "@babel/helper-get-function-arity": "^7.16.7",
     "@compodoc/compodoc": "1.1.19",
-    "@okta/okta-auth-js": "^7.0.0",
+    "@okta/okta-auth-js": "^7.1.0",
     "@types/jest": "^26.0.14",
     "@types/json-schema": "^7.0.3",
     "@types/node": "10.14.0",

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -10,6 +10,7 @@ fi
 setup_service java 1.8.222
 setup_service google-chrome-stable 106.0.5249.61-1
 
+export AUTHJS_VERSION_6="true"
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 

--- a/scripts/unit-v6.sh
+++ b/scripts/unit-v6.sh
@@ -7,6 +7,7 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
   exit ${SUCCESS}
 fi
 
+export AUTHJS_VERSION_6="true"
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/unit"
 

--- a/test/apps/angular-v12/src/app/app.component.ts
+++ b/test/apps/angular-v12/src/app/app.component.ts
@@ -26,6 +26,8 @@ import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
     [queryParams]="{ fooParams: 'foo' }"> Protected Page w/ custom config </button>
   <button id="public-button" routerLink="/public"> Parent Route (public) </button>
   <button id="private-button" routerLink="/public/private"> Child Route (private) </button>
+  <button id="1fa-button" routerLink="/public/1fa"> Step-up Route (1fa) </button>
+  <button id="2fa-button" routerLink="/public/2fa"> Step-up Route (2fa) </button>
   <button id="group-button" routerLink="/group"> Has Group </button>
   <router-outlet></router-outlet>
   `,

--- a/test/apps/angular-v12/src/app/app.module.ts
+++ b/test/apps/angular-v12/src/app/app.module.ts
@@ -81,6 +81,20 @@ const appRoutes: Routes = [
       {
         path: 'private',
         component: ProtectedComponent
+      },
+      {
+        path: '2fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:2fa:any'
+        },
+      },
+      {
+        path: '1fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:1fa:any'
+        },
       }
     ]
   },

--- a/test/apps/angular-v12/src/app/app.module.ts
+++ b/test/apps/angular-v12/src/app/app.module.ts
@@ -86,14 +86,18 @@ const appRoutes: Routes = [
         path: '2fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         },
       },
       {
         path: '1fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:1fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:1fa:any'
+          }
         },
       }
     ]

--- a/test/apps/angular-v12/src/app/protected.component.ts
+++ b/test/apps/angular-v12/src/app/protected.component.ts
@@ -20,12 +20,14 @@ import { OktaAuth } from '@okta/okta-auth-js';
   template: `
   <div>
   {{ message }}<br/>
-  <pre id="userinfo-container">{{ user }}</pre>
+  Claims: <pre id="claims-container">{{ claims }}</pre>
+  User: <pre id="userinfo-container">{{ user }}</pre>
   </div>`
 })
 export class ProtectedComponent implements OnInit {
   message;
   user = '';
+  claims = '';
 
   constructor(@Inject(OKTA_AUTH) public oktaAuth: OktaAuth) {
     this.message = 'Protected!';
@@ -34,5 +36,7 @@ export class ProtectedComponent implements OnInit {
   async ngOnInit() {
     const user = await this.oktaAuth.getUser();
     this.user = JSON.stringify(user, null, 4);
+    const claims = await this.oktaAuth.authStateManager.getAuthState()?.accessToken?.claims;
+    this.claims = JSON.stringify(claims, null, 4);
   }
 }

--- a/test/apps/angular-v12/yarn.lock
+++ b/test/apps/angular-v12/yarn.lock
@@ -1329,14 +1329,6 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime-corejs3@^7.17.0":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz#d7dd49fb812f29c61c59126da3792d8740d4e284"
-  integrity sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==
-  dependencies:
-    core-js-pure "^3.20.2"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
@@ -1896,24 +1888,23 @@
     read-package-json-fast "^2.0.1"
 
 "@okta/okta-auth-js@*":
-  version "6.7.6"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.7.6.tgz#31745df22f31e981d18bd0ec1fe85fcb9aa1b4c7"
-  integrity sha512-HUhy0+cccTPRRvlswDkeRt205cAPm+Z+51Xm8nTsnKn5+tWVDZ86Rq8w7JDsr+HjUQGZpdUxRP3Er+vEcoVcgg==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.2.0.tgz#7380d1ab8a5d62ce289a1320346079ff24d58cee"
+  integrity sha512-0YZ8cEbTGwlw9KGey+4ZnGJs4qKs8PkQsbaCyQ1q9jKMftuDlGXL85jrLpnEqg3jfYCpi6GDtEl/QquOKMvAFw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.17.0"
     "@peculiar/webcrypto" "^1.4.0"
     Base64 "1.1.0"
     atob "^2.1.2"
-    broadcast-channel "4.13.0"
+    broadcast-channel "~4.17.0"
     btoa "^1.2.1"
     core-js "^3.6.5"
     cross-fetch "^3.1.5"
+    fast-text-encoding "^1.0.6"
     js-cookie "^3.0.1"
     jsonpath-plus "^6.0.1"
     node-cache "^5.1.2"
     p-cancelable "^2.0.0"
-    text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
@@ -2941,14 +2932,12 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-broadcast-channel@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
-  integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
+broadcast-channel@~4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.17.0.tgz#599d44674b09a4e2e07af6da5d03b45ca8bffd11"
+  integrity sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==
   dependencies:
     "@babel/runtime" "^7.16.0"
-    detect-node "^2.1.0"
-    microtime "3.0.0"
     oblivious-set "1.1.1"
     p-queue "6.6.2"
     rimraf "3.0.2"
@@ -3632,11 +3621,6 @@ core-js-compat@^3.15.0, core-js-compat@^3.16.2:
     browserslist "^4.17.6"
     semver "7.0.0"
 
-core-js-pure@^3.20.2:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
-  integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
-
 core-js@3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.16.0.tgz#1d46fb33720bc1fa7f90d20431f36a5540858986"
@@ -4085,7 +4069,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@2.1.0, detect-node@^2.0.4, detect-node@^2.1.0:
+detect-node@2.1.0, detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -4822,6 +4806,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -6969,14 +6958,6 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-microtime@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.0.0.tgz#d140914bde88aa89b4f9fd2a18620b435af0f39b"
-  integrity sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==
-  dependencies:
-    node-addon-api "^1.2.0"
-    node-gyp-build "^3.8.0"
-
 mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
@@ -7237,11 +7218,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-addon-api@^1.2.0:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
 node-addon-api@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -7265,11 +7241,6 @@ node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-gyp-build@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
-  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 node-gyp-build@^4.2.2:
   version "4.3.0"
@@ -9807,11 +9778,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-table@0.2.0:
   version "0.2.0"

--- a/test/apps/angular-v13/src/app/app.component.ts
+++ b/test/apps/angular-v13/src/app/app.component.ts
@@ -26,6 +26,8 @@ import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
     [queryParams]="{ fooParams: 'foo' }"> Protected Page w/ custom config </button>
   <button id="public-button" routerLink="/public"> Parent Route (public) </button>
   <button id="private-button" routerLink="/public/private"> Child Route (private) </button>
+  <button id="1fa-button" routerLink="/public/1fa"> Step-up Route (1fa) </button>
+  <button id="2fa-button" routerLink="/public/2fa"> Step-up Route (2fa) </button>
   <button id="group-button" routerLink="/group"> Has Group </button>
   <router-outlet></router-outlet>
   `,

--- a/test/apps/angular-v13/src/app/app.module.ts
+++ b/test/apps/angular-v13/src/app/app.module.ts
@@ -81,6 +81,20 @@ const appRoutes: Routes = [
       {
         path: 'private',
         component: ProtectedComponent
+      },
+      {
+        path: '2fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:2fa:any'
+        },
+      },
+      {
+        path: '1fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:1fa:any'
+        },
       }
     ]
   },

--- a/test/apps/angular-v13/src/app/app.module.ts
+++ b/test/apps/angular-v13/src/app/app.module.ts
@@ -86,14 +86,18 @@ const appRoutes: Routes = [
         path: '2fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         },
       },
       {
         path: '1fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:1fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:1fa:any'
+          }
         },
       }
     ]

--- a/test/apps/angular-v13/src/app/protected.component.ts
+++ b/test/apps/angular-v13/src/app/protected.component.ts
@@ -20,12 +20,14 @@ import { OktaAuth } from '@okta/okta-auth-js';
   template: `
   <div>
   {{ message }}<br/>
-  <pre id="userinfo-container">{{ user }}</pre>
+  Claims: <pre id="claims-container">{{ claims }}</pre>
+  User: <pre id="userinfo-container">{{ user }}</pre>
   </div>`
 })
 export class ProtectedComponent implements OnInit {
   message;
   user = '';
+  claims = '';
 
   constructor(@Inject(OKTA_AUTH) public oktaAuth: OktaAuth) {
     this.message = 'Protected!';
@@ -34,5 +36,7 @@ export class ProtectedComponent implements OnInit {
   async ngOnInit() {
     const user = await this.oktaAuth.getUser();
     this.user = JSON.stringify(user, null, 4);
+    const claims = await this.oktaAuth.authStateManager.getAuthState()?.accessToken?.claims;
+    this.claims = JSON.stringify(claims, null, 4);
   }
 }

--- a/test/apps/angular-v13/yarn.lock
+++ b/test/apps/angular-v13/yarn.lock
@@ -1334,14 +1334,6 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime-corejs3@^7.17.0":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz#d7dd49fb812f29c61c59126da3792d8740d4e284"
-  integrity sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==
-  dependencies:
-    core-js-pure "^3.20.2"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
@@ -1882,24 +1874,23 @@
     read-package-json-fast "^2.0.1"
 
 "@okta/okta-auth-js@*":
-  version "6.7.6"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.7.6.tgz#31745df22f31e981d18bd0ec1fe85fcb9aa1b4c7"
-  integrity sha512-HUhy0+cccTPRRvlswDkeRt205cAPm+Z+51Xm8nTsnKn5+tWVDZ86Rq8w7JDsr+HjUQGZpdUxRP3Er+vEcoVcgg==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.2.0.tgz#7380d1ab8a5d62ce289a1320346079ff24d58cee"
+  integrity sha512-0YZ8cEbTGwlw9KGey+4ZnGJs4qKs8PkQsbaCyQ1q9jKMftuDlGXL85jrLpnEqg3jfYCpi6GDtEl/QquOKMvAFw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.17.0"
     "@peculiar/webcrypto" "^1.4.0"
     Base64 "1.1.0"
     atob "^2.1.2"
-    broadcast-channel "4.13.0"
+    broadcast-channel "~4.17.0"
     btoa "^1.2.1"
     core-js "^3.6.5"
     cross-fetch "^3.1.5"
+    fast-text-encoding "^1.0.6"
     js-cookie "^3.0.1"
     jsonpath-plus "^6.0.1"
     node-cache "^5.1.2"
     p-cancelable "^2.0.0"
-    text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
@@ -2818,14 +2809,12 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-broadcast-channel@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
-  integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
+broadcast-channel@~4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.17.0.tgz#599d44674b09a4e2e07af6da5d03b45ca8bffd11"
+  integrity sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==
   dependencies:
     "@babel/runtime" "^7.16.0"
-    detect-node "^2.1.0"
-    microtime "3.0.0"
     oblivious-set "1.1.1"
     p-queue "6.6.2"
     rimraf "3.0.2"
@@ -3400,11 +3389,6 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2:
     browserslist "^4.17.6"
     semver "7.0.0"
 
-core-js-pure@^3.20.2:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
-  integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
-
 core-js@3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.0.tgz#9e40098a9bc326c7e81b486abbd5e12b9d275176"
@@ -3727,7 +3711,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@2.1.0, detect-node@^2.0.4, detect-node@^2.1.0:
+detect-node@2.1.0, detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -4509,6 +4493,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -6309,14 +6298,6 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-microtime@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.0.0.tgz#d140914bde88aa89b4f9fd2a18620b435af0f39b"
-  integrity sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==
-  dependencies:
-    node-addon-api "^1.2.0"
-    node-gyp-build "^3.8.0"
-
 mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
@@ -6539,11 +6520,6 @@ nice-napi@^1.0.2:
     node-addon-api "^3.0.0"
     node-gyp-build "^4.2.2"
 
-node-addon-api@^1.2.0:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
 node-addon-api@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -6567,11 +6543,6 @@ node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-gyp-build@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
-  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 node-gyp-build@^4.2.2:
   version "4.3.0"
@@ -8557,11 +8528,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-table@0.2.0:
   version "0.2.0"

--- a/test/apps/angular-v14/src/app/app.component.ts
+++ b/test/apps/angular-v14/src/app/app.component.ts
@@ -26,6 +26,8 @@ import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
     [queryParams]="{ fooParams: 'foo' }"> Protected Page w/ custom config </button>
   <button id="public-button" routerLink="/public"> Parent Route (public) </button>
   <button id="private-button" routerLink="/public/private"> Child Route (private) </button>
+  <button id="1fa-button" routerLink="/public/1fa"> Step-up Route (1fa) </button>
+  <button id="2fa-button" routerLink="/public/2fa"> Step-up Route (2fa) </button>
   <button id="group-button" routerLink="/group"> Has Group </button>
   <router-outlet></router-outlet>
   `,

--- a/test/apps/angular-v14/src/app/app.module.ts
+++ b/test/apps/angular-v14/src/app/app.module.ts
@@ -81,6 +81,20 @@ const appRoutes: Routes = [
       {
         path: 'private',
         component: ProtectedComponent
+      },
+      {
+        path: '2fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:2fa:any'
+        },
+      },
+      {
+        path: '1fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:1fa:any'
+        },
       }
     ]
   },

--- a/test/apps/angular-v14/src/app/app.module.ts
+++ b/test/apps/angular-v14/src/app/app.module.ts
@@ -86,14 +86,18 @@ const appRoutes: Routes = [
         path: '2fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         },
       },
       {
         path: '1fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:1fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:1fa:any'
+          }
         },
       }
     ]

--- a/test/apps/angular-v14/src/app/protected.component.ts
+++ b/test/apps/angular-v14/src/app/protected.component.ts
@@ -20,12 +20,14 @@ import { OktaAuth } from '@okta/okta-auth-js';
   template: `
   <div>
   {{ message }}<br/>
-  <pre id="userinfo-container">{{ user }}</pre>
+  Claims: <pre id="claims-container">{{ claims }}</pre>
+  User: <pre id="userinfo-container">{{ user }}</pre>
   </div>`
 })
 export class ProtectedComponent implements OnInit {
   message;
   user = '';
+  claims = '';
 
   constructor(@Inject(OKTA_AUTH) public oktaAuth: OktaAuth) {
     this.message = 'Protected!';
@@ -34,5 +36,7 @@ export class ProtectedComponent implements OnInit {
   async ngOnInit() {
     const user = await this.oktaAuth.getUser();
     this.user = JSON.stringify(user, null, 4);
+    const claims = await this.oktaAuth.authStateManager.getAuthState()?.accessToken?.claims;
+    this.claims = JSON.stringify(claims, null, 4);
   }
 }

--- a/test/apps/angular-v15/src/app/app.component.ts
+++ b/test/apps/angular-v15/src/app/app.component.ts
@@ -26,6 +26,8 @@ import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
     [queryParams]="{ fooParams: 'foo' }"> Protected Page w/ custom config </button>
   <button id="public-button" routerLink="/public"> Parent Route (public) </button>
   <button id="private-button" routerLink="/public/private"> Child Route (private) </button>
+  <button id="1fa-button" routerLink="/public/1fa"> Step-up Route (1fa) </button>
+  <button id="2fa-button" routerLink="/public/2fa"> Step-up Route (2fa) </button>
   <button id="group-button" routerLink="/group"> Has Group </button>
   <router-outlet></router-outlet>
   `,

--- a/test/apps/angular-v15/src/app/app.module.ts
+++ b/test/apps/angular-v15/src/app/app.module.ts
@@ -80,7 +80,21 @@ const appRoutes: Routes = [
     children: [
       {
         path: 'private',
-        component: ProtectedComponent
+        component: ProtectedComponent,
+      },
+      {
+        path: '2fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:2fa:any'
+        },
+      },
+      {
+        path: '1fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:1fa:any'
+        },
       }
     ]
   },

--- a/test/apps/angular-v15/src/app/app.module.ts
+++ b/test/apps/angular-v15/src/app/app.module.ts
@@ -86,14 +86,18 @@ const appRoutes: Routes = [
         path: '2fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         },
       },
       {
         path: '1fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:1fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:1fa:any'
+          }
         },
       }
     ]

--- a/test/apps/angular-v15/src/app/protected.component.ts
+++ b/test/apps/angular-v15/src/app/protected.component.ts
@@ -20,12 +20,14 @@ import { OktaAuth } from '@okta/okta-auth-js';
   template: `
   <div>
   {{ message }}<br/>
-  <pre id="userinfo-container">{{ user }}</pre>
+  Claims: <pre id="claims-container">{{ claims }}</pre>
+  User: <pre id="userinfo-container">{{ user }}</pre>
   </div>`
 })
 export class ProtectedComponent implements OnInit {
   message;
   user = '';
+  claims = '';
 
   constructor(@Inject(OKTA_AUTH) public oktaAuth: OktaAuth) {
     this.message = 'Protected!';
@@ -34,5 +36,7 @@ export class ProtectedComponent implements OnInit {
   async ngOnInit() {
     const user = await this.oktaAuth.getUser();
     this.user = JSON.stringify(user, null, 4);
+    const claims = await this.oktaAuth.authStateManager.getAuthState()?.accessToken?.claims;
+    this.claims = JSON.stringify(claims, null, 4);
   }
 }

--- a/test/apps/angular-v16/src/app/app.component.ts
+++ b/test/apps/angular-v16/src/app/app.component.ts
@@ -26,6 +26,8 @@ import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
     [queryParams]="{ fooParams: 'foo' }"> Protected Page w/ custom config </button>
   <button id="public-button" routerLink="/public"> Parent Route (public) </button>
   <button id="private-button" routerLink="/public/private"> Child Route (private) </button>
+  <button id="1fa-button" routerLink="/public/1fa"> Step-up Route (1fa) </button>
+  <button id="2fa-button" routerLink="/public/2fa"> Step-up Route (2fa) </button>
   <button id="group-button" routerLink="/group"> Has Group </button>
   <router-outlet></router-outlet>
   `,

--- a/test/apps/angular-v16/src/app/app.module.ts
+++ b/test/apps/angular-v16/src/app/app.module.ts
@@ -81,6 +81,20 @@ const appRoutes: Routes = [
       {
         path: 'private',
         component: ProtectedComponent
+      },
+      {
+        path: '2fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:2fa:any'
+        },
+      },
+      {
+        path: '1fa',
+        component: ProtectedComponent,
+        data: {
+          acrValues: 'urn:okta:loa:1fa:any'
+        },
       }
     ]
   },

--- a/test/apps/angular-v16/src/app/app.module.ts
+++ b/test/apps/angular-v16/src/app/app.module.ts
@@ -86,14 +86,18 @@ const appRoutes: Routes = [
         path: '2fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         },
       },
       {
         path: '1fa',
         component: ProtectedComponent,
         data: {
-          acrValues: 'urn:okta:loa:1fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:1fa:any'
+          }
         },
       }
     ]

--- a/test/apps/angular-v16/src/app/protected.component.ts
+++ b/test/apps/angular-v16/src/app/protected.component.ts
@@ -20,12 +20,14 @@ import { OktaAuth } from '@okta/okta-auth-js';
   template: `
   <div>
   {{ message }}<br/>
-  <pre id="userinfo-container">{{ user }}</pre>
+  Claims: <pre id="claims-container">{{ claims }}</pre>
+  User: <pre id="userinfo-container">{{ user }}</pre>
   </div>`
 })
 export class ProtectedComponent implements OnInit {
   message;
   user = '';
+  claims = '';
 
   constructor(@Inject(OKTA_AUTH) public oktaAuth: OktaAuth) {
     this.message = 'Protected!';
@@ -34,5 +36,7 @@ export class ProtectedComponent implements OnInit {
   async ngOnInit() {
     const user = await this.oktaAuth.getUser();
     this.user = JSON.stringify(user, null, 4);
+    const claims = await this.oktaAuth.authStateManager.getAuthState()?.accessToken?.claims;
+    this.claims = JSON.stringify(claims, null, 4);
   }
 }

--- a/test/e2e/pageobjects/protected.page.js
+++ b/test/e2e/pageobjects/protected.page.js
@@ -2,6 +2,7 @@ import { AppPage } from './app.page';
 
 class ProtectedPage extends AppPage {
   get userInfo() { return $('#userinfo-container') }
+  get claims() { return $('#claims-container') }
 
   async navigateTo(query) {
     query = query || '';
@@ -15,10 +16,30 @@ class ProtectedPage extends AppPage {
         .then(txt => !!txt.trim().length), 5000, 'wait for user info');
   }
 
+  async waitForClaims() {
+    return browser.waitUntil(async () => 
+      this.claims
+        .then(el => el.getText())
+        .then(txt => !!txt.trim().length), 5000, 'wait for claims');
+  }
+
   async assertUserInfo(username) {
     await this.waitForLoad();
     await this.userInfo.then(el => el.getText()).then(txt => {
       expect(txt).toContain(username);
+    });
+  }
+
+  async assertClaim(key, value) {
+    await this.waitForClaims();
+    await this.claims.then(el => el.getText()).then(txt => {
+      const claims = JSON.parse(txt);
+      if (!value) {
+        expect(claims[key]).not.toBeDefined();
+      } else {
+        expect(claims[key]).toBeDefined();
+        expect(claims[key]).toEqual(value);
+      }
     });
   }
 

--- a/test/e2e/specs/app.e2e.js
+++ b/test/e2e/specs/app.e2e.js
@@ -120,6 +120,10 @@ describe('Angular + Okta App', () => {
     });
 
     it('displays the child route "Step-up (1FA)" with Step-up authentication', async () => {
+      if (process.env.AUTHJS_VERSION_6) {
+        // skip
+        return;
+      }
       // 1. Go to /private with a standard authentication
       await PublicPage.navigateTo('/private');
       await OktaSignInPage.waitForLoad();

--- a/test/spec/auth-factory.service.test.ts
+++ b/test/spec/auth-factory.service.test.ts
@@ -8,7 +8,6 @@ jest.mock('../../lib/src/okta/packageInfo', () => ({
   __esModule: true,
   default: {
     authJSMinSupportedVersion: '5.3.1',
-    authJSMinSupportedVersionForAcr: '7.1.0',
     version: '99.9.9',
     name: '@okta/okta-angular',
   }

--- a/test/spec/auth-factory.service.test.ts
+++ b/test/spec/auth-factory.service.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../lib/src/okta/packageInfo', () => ({
   __esModule: true,
   default: {
     authJSMinSupportedVersion: '5.3.1',
+    authJSMinSupportedVersionForAcr: '7.1.0',
     version: '99.9.9',
     name: '@okta/okta-angular',
   }

--- a/test/spec/guard.test.ts
+++ b/test/spec/guard.test.ts
@@ -241,32 +241,6 @@ describe('Angular auth guard', () => {
   });
 
   describe('canActivate', () => {
-    it('throws AuthSdkError if acrValues is provided and auth-js version < 7.1.0', async () => {
-      const oktaAuth = {
-        isAuthenticated: jest.fn().mockResolvedValue(false),
-        authStateManager: {
-          subscribe: jest.fn()
-        },
-        _oktaUserAgent: {
-          getVersion: jest.fn().mockReturnValue('7.0.0')
-        }
-      } as unknown;
-      const configService = createConfigService({} as OktaConfig);
-      setup(oktaAuth as OktaAuth, {} as OktaConfig);
-      const injector: Injector = TestBed.get(Injector);
-      const guard = new OktaAuthGuard(oktaAuth as OktaAuth, injector as Injector, configService);
-      const route: unknown = {
-        data: {
-          acrValues: 'urn:okta:loa:2fa:any'
-        }
-      };
-      const state: unknown = {};
-      const guardCall = () => guard.canActivate(route as ActivatedRouteSnapshot, state as RouterStateSnapshot);
-      await expect(guardCall).rejects.toThrow(new AuthSdkError(
-        'Passed in oktaAuth does not support ACR values, minimum supported okta-auth-js version is 7.1.0.'
-      ));
-    });
-
     describe('isAuthenticated() = true', () => {
       it('returns true', async () => {
         const oktaAuth = {

--- a/test/spec/guard.test.ts
+++ b/test/spec/guard.test.ts
@@ -171,7 +171,9 @@ describe('Angular auth guard', () => {
         const guard = new OktaAuthGuard(oktaAuth as OktaAuth, injector as Injector, configService);
         const route: unknown = {
           data: {
-            acrValues: 'urn:okta:loa:2fa:any'
+            okta: {
+              acrValues: 'urn:okta:loa:2fa:any'
+            }
           }
         };
         const res = await guard.canLoad(route as Route);
@@ -208,7 +210,9 @@ describe('Angular auth guard', () => {
         guard = new OktaAuthGuard(oktaAuth, injector, configService);
         route = {
           data: {
-            acrValues: 'urn:okta:loa:2fa:any'
+            okta: {
+              acrValues: 'urn:okta:loa:2fa:any'
+            }
           }
         } as unknown as Route;
       });
@@ -351,7 +355,9 @@ describe('Angular auth guard', () => {
         const guard = new OktaAuthGuard(oktaAuth as OktaAuth, injector as Injector, configService);
         const route: unknown = {
           data: {
-            acrValues: 'urn:okta:loa:2fa:any'
+            okta: {
+              acrValues: 'urn:okta:loa:2fa:any'
+            }
           }
         };
         const state: unknown = {};
@@ -395,7 +401,9 @@ describe('Angular auth guard', () => {
         state = routerState.snapshot;
         route = state.root;
         route.data = {
-          acrValues: 'urn:okta:loa:2fa:any'
+          okta: {
+            acrValues: 'urn:okta:loa:2fa:any'
+          }
         };
       });
 

--- a/test/spec/guard.test.ts
+++ b/test/spec/guard.test.ts
@@ -16,7 +16,7 @@ import {
   Route
 } from '@angular/router';
 import { Injector } from '@angular/core';
-import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
+import { OktaAuth } from '@okta/okta-auth-js';
 
 jest.mock('../../lib/src/okta/packageInfo', () => ({
   __esModule: true,

--- a/test/spec/guard.test.ts
+++ b/test/spec/guard.test.ts
@@ -22,7 +22,6 @@ jest.mock('../../lib/src/okta/packageInfo', () => ({
   __esModule: true,
   default: {
     authJSMinSupportedVersion: '5.3.1',
-    authJSMinSupportedVersionForAcr: '7.1.0',
     version: '99.9.9',
     name: '@okta/okta-angular',
   }
@@ -63,31 +62,6 @@ describe('Angular auth guard', () => {
   });
 
   describe('canLoad', () => {
-    it('throws AuthSdkError if acrValues is provided and auth-js version < 7.1.0', async () => {
-      const oktaAuth = {
-        isAuthenticated: jest.fn().mockResolvedValue(false),
-        authStateManager: {
-          subscribe: jest.fn()
-        },
-        _oktaUserAgent: {
-          getVersion: jest.fn().mockReturnValue('7.0.0')
-        }
-      } as unknown;
-      const configService = createConfigService({} as OktaConfig);
-      setup(oktaAuth as OktaAuth, {} as OktaConfig);
-      const injector: Injector = TestBed.get(Injector);
-      const guard = new OktaAuthGuard(oktaAuth as OktaAuth, injector as Injector, configService);
-      const route: unknown = {
-        data: {
-          acrValues: 'urn:okta:loa:2fa:any'
-        }
-      };
-      const guardCall = () => guard.canLoad(route as Route);
-      await expect(guardCall).rejects.toThrow(new AuthSdkError(
-        'Passed in oktaAuth does not support ACR values, minimum supported okta-auth-js version is 7.1.0.'
-      ));
-    });
-
     describe('isAuthenticated() = true', () => {
       it('returns true', async () => {
         const oktaAuth = {

--- a/util/write-package-info.js
+++ b/util/write-package-info.js
@@ -11,8 +11,7 @@ const packageJson = require(packageJsonPath);
 const packageInfo = {
   name: packageJson.name,
   version: packageJson.version,
-  authJSMinSupportedVersion: '5.3.1',
-  authJSMinSupportedVersionForAcr: '7.1.0'
+  authJSMinSupportedVersion: '5.3.1'
 };
 const output = 'export default ' + JSON.stringify(packageInfo, null, 2).replace(/"/g, '\'') + ';\n';
 

--- a/util/write-package-info.js
+++ b/util/write-package-info.js
@@ -11,7 +11,8 @@ const packageJson = require(packageJsonPath);
 const packageInfo = {
   name: packageJson.name,
   version: packageJson.version,
-  authJSMinSupportedVersion: '5.3.1'
+  authJSMinSupportedVersion: '5.3.1',
+  authJSMinSupportedVersionForAcr: '7.1.0'
 };
 const output = 'export default ' + JSON.stringify(packageInfo, null, 2).replace(/"/g, '\'') + ';\n';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,10 +3063,10 @@
   dependencies:
     "@octokit/openapi-types" "^16.0.0"
 
-"@okta/okta-auth-js@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.2.0.tgz#7380d1ab8a5d62ce289a1320346079ff24d58cee"
-  integrity sha512-0YZ8cEbTGwlw9KGey+4ZnGJs4qKs8PkQsbaCyQ1q9jKMftuDlGXL85jrLpnEqg3jfYCpi6GDtEl/QquOKMvAFw==
+"@okta/okta-auth-js@^7.1.0":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.4.2.tgz#f3b110779293c30b072c67ea1ab78c3188ce9443"
+  integrity sha512-7FV40urxesNv7pn5O0/7JeQKoXpbePqbj3qQTDn/2trKd+M2cDjXpOLebbTYs07iSK/YbsUkQXsvnJI5F5Pyqg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@peculiar/webcrypto" "^1.4.0"


### PR DESCRIPTION
## Description
Added support of [Step-up authentication](https://developer.okta.com/docs/guides/step-up-authentication/main/) in `OktaAuthGuard` by specifying [`acrValues`](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) in route data.
If current token does not have requested level of assurance, there will be a redirect to `/authorize` endpoint with provided `acr_values` in query parameters
Minimum supported version of okta-auth-js for this feature is 7.1.0
Changes for test apps:
- added 2 buttons: "Step-up Route (1fa)" (protected route, requires any factor) and "Step-up Route (2fa)" (protected route, requires 2 factors)
- changed protected component: now it renders user info and token claims (to check `acr` claim)

Resolves https://github.com/okta/okta-angular/issues/125
Internal ref: OKTA-597151

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-angular/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


